### PR TITLE
luzer: reserve and handoff ctrs to lf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration with libFuzzer's `FuzzedDataProvider`.
 - Examples with tests.
 - Documentation with usecases, API etc.
+- Two ways to approximate amount of counters for interpreted code.
+
+### Fixed
+- Interpreted code counter never handed to libfuzzer. (#12)
+- Bad lifetime and initization of struct sigaction.

--- a/luzer/CMakeLists.txt
+++ b/luzer/CMakeLists.txt
@@ -23,6 +23,7 @@ set(LUZER_SOURCES luzer.c
                   fuzzed_data_provider.cc
                   tracer.c
                   counters.c
+		  io.cc
                   ${CMAKE_CURRENT_BINARY_DIR}/version.c)
 
 add_library(${CMAKE_PROJECT_NAME} SHARED ${LUZER_SOURCES})

--- a/luzer/io.cc
+++ b/luzer/io.cc
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: ISC
+ *
+ */
+#include <vector>
+#include <string>
+#include <cstdint>
+/**
+ * Okay, we all know this is bad, but unless we want to include third-party
+ * headers or libs to do crossplatform IO (damn Windows cannot into readdir)
+ * we better use whatever libfuzzer... shyly gives to us with no guarantees.
+ * Remember - those things do not have ATTRIBUTE_INTERFACE in LF's codebase.
+ * Bu-u-u-ut libfuzzer is pretty much in maintenance mode so I think it's
+ * safe.
+ * What's worse than using non-public-API is using C++. But this project already
+ * uses clang++ with 'fuzzed_data_provider.cc'. Hey, libfuzzer IS written in C++.
+ */
+
+extern "C" {
+#include "macros.h"
+
+	int map_over_dir_contents(char const *dirpath, int (*user_cb)(uint8_t const *data, size_t length));
+}
+
+/**
+ * See link for source of this
+ * https://github.com/llvm/llvm-project/blob/493cc71d72c471c841b490f30dd8f26f3a0d89de/compiler-rt/lib/fuzzer/FuzzerDefs.h#L41
+ */
+typedef std::vector<uint8_t> Unit;
+
+/**
+ * See link for source of this
+ * https://github.com/llvm/llvm-project/blob/493cc71d72c471c841b490f30dd8f26f3a0d89de/compiler-rt/lib/fuzzer/FuzzerIO.cpp#L101
+ */
+namespace fuzzer {
+	void ReadDirToVectorOfUnits(
+		const char *Path,
+		std::vector<Unit> *V, long *Epoch,
+		size_t MaxSize,
+		bool ExitOnError,
+		std::vector<std::string> *VPaths);
+	bool IsDirectory(const std::string &Path);
+}
+
+NO_SANITIZE int
+map_over_dir_contents(char const *dirpath, int (*user_cb)(uint8_t const * data, size_t length))
+{
+	if (nullptr == user_cb || nullptr == dirpath) {
+		return -1;
+	}
+
+	if (!fuzzer::IsDirectory(dirpath)) {
+		return -2;
+	}
+
+	std::vector<Unit> seed_corpus;
+	fuzzer::ReadDirToVectorOfUnits(
+			dirpath,
+		       	&seed_corpus,
+		       	/*Epoch = */nullptr,
+		       	/*MaxSize = */SIZE_MAX,
+		       	/*ExitOnError = */false,
+			/*VPaths = */nullptr
+			);
+
+	for (auto unit : seed_corpus) {
+		user_cb(unit.data(), unit.size());
+	}
+	return 0;
+}
+

--- a/luzer/tracer.c
+++ b/luzer/tracer.c
@@ -41,7 +41,8 @@ _trace_branch(uint64_t idx)
 	increment_counter(idx);
 }
 
-static inline unsigned int lhash(const char *key, size_t offset)
+NO_SANITIZE static inline unsigned int
+lhash(const char *key, size_t offset)
 {
 	const char *const last = &key[strlen(key) - 1];
 	uint32_t h = LHASH_INIT;
@@ -61,7 +62,8 @@ static inline unsigned int lhash(const char *key, size_t offset)
  * https://github.com/lunarmodules/luacov/blob/master/src/luacov/runner.lua#L102-L117
  * https://github.com/lunarmodules/luacov/blob/78f3d5058c65f9712e6c50a0072ad8160db4d00e/src/luacov/runner.lua#L439-L450
  */
-void debug_hook(lua_State *L, lua_Debug *ar)
+NO_SANITIZE void
+debug_hook(lua_State *L, lua_Debug *ar)
 {
 	lua_getinfo(L, "Sln", ar);
 	if (ar && ar->source && ar->currentline) {
@@ -69,3 +71,17 @@ void debug_hook(lua_State *L, lua_Debug *ar)
 		_trace_branch(new_location);
 	}
 }
+
+/**
+ * this one is used before we allocate counters to get general idea
+ * about how much of them do we need for interpreted code
+ */
+NO_SANITIZE void
+collector_debug_hook(lua_State *L, lua_Debug *ar)
+{
+	lua_getinfo(L, "Sln", ar);
+	if (ar && ar->source && ar->currentline) {
+		reserve_counter();
+	}
+}
+

--- a/luzer/tracer.h
+++ b/luzer/tracer.h
@@ -2,5 +2,6 @@
 #define LUZER_TRACER_H_
 
 void debug_hook(lua_State *L, lua_Debug *ar);
+void collector_debug_hook(lua_State *L, lua_Debug *ar);
 
 #endif  // LUZER_TRACER_H_


### PR DESCRIPTION
Until now, luzer had not used at all coverage information for interpreted code. Hook-based instrumentation collected data, but it were never passed to libfuzzer to drew features from. Memory always were allocated in a fixed default kMax... size. This commit includes a fix to properly pass counters to libfuzzer, two systems to approximate optimal amount of 8-bit counters: one based on testing, pre-run phase, and one based on active bytecode size. Also, a minor fix to signal handling.

Fixes #12