### PR TITLE
luzer: rm fuzzer internals cov instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration with libFuzzer's `FuzzedDataProvider`.
 - Examples with tests.
 - Documentation with usecases, API etc.
+
+### Fixed
+- Interfering coverage instrumentation of fuzzer internals (#11)
+

--- a/luzer/macros.h
+++ b/luzer/macros.h
@@ -36,6 +36,20 @@
 #define NO_SANITIZE_MEMORY
 #endif  // __has_attribute
 
-#define NO_SANITIZE NO_SANITIZE_ADDRESS NO_SANITIZE_MEMORY
+// https://clang.llvm.org/docs/SanitizerCoverage.html#disabling-instrumentation-with-attribute-no-sanitize-coverage
+#ifdef __has_feature
+
+#if __has_feature(coverage_sanitizer)
+#define NO_SANITIZE_COVERAGE __attribute__((no_sanitize("coverage")))
+#else // __has_feature(coverage_sanitizer)
+#warning "compiler does not provide 'coverage_sanitizer' feature"
+#define NO_SANITIZE_COVERAGE
+#endif // __has_feature(coverage_sanitizer)
+
+#else // __has_feature
+#warning "compiler does not provide __has_feature, can't check for sanitization"
+#endif // __has_feature
+
+#define NO_SANITIZE NO_SANITIZE_ADDRESS NO_SANITIZE_MEMORY NO_SANITIZE_COVERAGE
 
 #endif  // LUZER_MACROS_H_


### PR DESCRIPTION
Before this commit, most internal functions were marked with attributes to protect them from Address Sanitizer. This was meant clang still instrumented code with coverage collection, slowing down hot path AND unstabilizing fuzzing process by damaging real target coverage.

Fixes #11